### PR TITLE
 Use get_template_directory(), Fix #32

### DIFF
--- a/front-page1.php
+++ b/front-page1.php
@@ -25,7 +25,7 @@
 wp_head();
 ?>
 <body <?php body_class( 'front-page' );  // clear class is added so the footer and its bottom margin fit into the body         ?>>
-    <img src="<?php echo get_stylesheet_directory_uri() ?>/images/under_construction.jpg" alt="האתר בבנייה. מיד נשוב">
+    <img src="<?php echo get_template_directory_uri() ?>/images/under_construction.jpg" alt="האתר בבנייה. מיד נשוב">
     <?php wp_footer(); ?>
 </body>
 </html>

--- a/functions.php
+++ b/functions.php
@@ -184,11 +184,11 @@ function kamoha_scripts() {
         $kamoha_custom_css = "
             @font-face {
             font-family: 'icomoon';
-            src:url('" . get_stylesheet_directory_uri() . "/fonts/icomoon.eot?-416wh5');"
-                . "src:url('" . get_stylesheet_directory_uri() . "/fonts/icomoon.eot?#iefix-416wh5') format('embedded-opentype'),"
-                . "url('" . get_stylesheet_directory_uri() . "/fonts/icomoon.woff?-416wh5') format('woff'),"
-                . "url('" . get_stylesheet_directory_uri() . "/fonts/icomoon.ttf?-416wh5') format('truetype'),"
-                . "url('" . get_stylesheet_directory_uri() . "/fonts/icomoon.svg?-416wh5#icomoon') format('svg');"
+            src:url('" . get_template_directory_uri() . "/fonts/icomoon.eot?-416wh5');"
+                . "src:url('" . get_template_directory_uri() . "/fonts/icomoon.eot?#iefix-416wh5') format('embedded-opentype'),"
+                . "url('" . get_template_directory_uri() . "/fonts/icomoon.woff?-416wh5') format('woff'),"
+                . "url('" . get_template_directory_uri() . "/fonts/icomoon.ttf?-416wh5') format('truetype'),"
+                . "url('" . get_template_directory_uri() . "/fonts/icomoon.svg?-416wh5#icomoon') format('svg');"
                 . "font-weight: normal;"
                 . "font-style: normal;}";
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -218,7 +218,7 @@ if ( !function_exists( 'admin_thumb_column' ) ) {
 /**
  * Include the TGM_Plugin_Activation class.
  */
-require_once get_stylesheet_directory() . '/inc/class-tgm-plugin-activation.php';
+require_once get_template_directory() . '/inc/class-tgm-plugin-activation.php';
 
 add_action( 'tgmpa_register', 'kamoha_register_required_plugins' );
 
@@ -245,7 +245,7 @@ function kamoha_register_required_plugins(){
         array(
             'name' => 'Demo Tax meta class',
             'slug' => 'bainternet-Tax-Meta-Class',
-            'source' => get_stylesheet_directory() . '/inc/plugins/bainternet-Tax-Meta-Class.zip', // The plugin source.
+            'source' => get_template_directory() . '/inc/plugins/bainternet-Tax-Meta-Class.zip', // The plugin source.
             'required' => false,
             'force_deactivation' => false,
         ),
@@ -292,7 +292,7 @@ function kamoha_register_required_plugins(){
         array(
             'name' => 'TF FAQ',
             'slug' => 'tf-faq',
-            'source' => get_stylesheet_directory() . '/inc/plugins/tf-faq.zip', // The plugin source.
+            'source' => get_template_directory() . '/inc/plugins/tf-faq.zip', // The plugin source.
             'required' => false,
         ),
         array(

--- a/page_without-header-and-footer.php
+++ b/page_without-header-and-footer.php
@@ -8,7 +8,6 @@
     <head>
         <meta charset="<?php bloginfo( 'charset' ); ?>">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="shortcut icon" href="<?php echo get_stylesheet_directory_uri() ?>/favicon.ico" />
         <link rel="profile" href="http://gmpg.org/xfn/11">
         <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
         <?php wp_head(); ?>


### PR DESCRIPTION
There were 10 instances of get_stylesheet_directory() and get_stylesheet_directory_uri() within the theme. These all changed to get_template_directory() and get_template_directory_uri(), respectively.